### PR TITLE
issue-1: Export exercise code to text files

### DIFF
--- a/src/ExercismPharoTooling.package/Exercism.class/README.md
+++ b/src/ExercismPharoTooling.package/Exercism.class/README.md
@@ -4,16 +4,46 @@ I am an exporter for code solutions created for the Pharo language track of Exer
 ## Description
 This tool re-uses parts _file out_ feature already built into Pharo. It exports two files containing the  Smalltalk code from a class. One file is place in the `<exercise>` directory. The other file is placed in the `<exercise>/.ghost` directory.
 
-Files in the root of the `<exercise>` directory have been scrubbed of all meta data and machine artifacts to improve readability. These files are for viewing code on Exercism.io.
+I do not create the directory tree for the exercise. I assume it has already been created by the exercism command line tool with `exercism fetch pharo`. For the exercise `hello-world` I would expect to see this directory tree:
+
+```shell
+HelloWorld/
+|-- .ghost/
+|     |-- HelloWorld.st
+|     |-- HelloWorldTest.st
+|-- HelloWorld.st
+|-- HelloWorldTest.st
+ ```
+
+Files in the root of the `HelloWorld` directory have been scrubbed of all meta data and machine artifacts to improve readability. These files are for viewing code on Exercism.io.
 
 The `.ghost` directory files contain the additional meta data that is needed to make them machine readable. This allows them to be _filed in_ to another Pharo image. 
 
 In keeping with Exercism convention, solutions should be exported to the directory `HOME/exercism/pharo/<exercise>` where `<exercise>` is the name of the class being exported, and the name of the exercise the solution is for. The value for this directory is available in the class method #exercismDirectory in the 'constants' protocol.
 
+### Usage
+Write your solution to an exercise in a class. After a solution to an exercise has been made, in the Playground enter the following message send, then right click with the mouse and select `Do it`. Replace the `HelloWorld` with the name of the class you want to export (unless you really want to export the `HelloWorld` class):
+```smalltalk
+Exercism exportClass: HelloWorld
+```
+
+#### Assumptions
+- The name of the class to be exported is the same as the exercise name.
+
 ### Instance Variables
-`homeDirectory` - The users HOME directory, typically available as an environment variable from the Operating System.
-`exercismDirectory` - The directory containing the Exercism exercises. This will typically be `exercism/pharo/`.
+`exerciseDirectory` - The directory containing the Exercism exercises. This will typically be `exercism/pharo/<exercise-name>`.
+`exportFile` - The name of the file being exported. Both the human and machine readable files share this name.
+`ghostDirectory` - The directory containing the machine readable files. These can be _filed in_ to a Pharo image.
+`exerciseClass` - The class containing the exercise solution. 
 
 ### Constants
-`exercismDirectory` - The directory to which files will be exported.
+Constants are provided as class methods that simply return the expected value.
+`exercismDirectory` - The parent directory of the Exercism Pharo language track.
 `fileExtension` - The file extension of the exported code file.
+`ghostDirectory` - The directory for hiding machine readable files not for human editing or reading.
+
+### Troubleshooting
+These are some possible errors that may be encountered, or have been encountered in development, and the known cause and solution for them.
+
+#### #nextChunkPut: was sent to nil
+To export the code a `FileStream` must be created. The file path provided to the `FileStream` must already exist on the computer. If it doesn't the `FileStream` will be `nil`. The file path should  be created when the exercise is downloaded with `exercism fetch pharo <exercise-name>`. The file path provided to `FileStream` might not match with the correct path. The code for this is in `Exercism>>#exportClass:`.

--- a/src/ExercismPharoTooling.package/Exercism.class/class/buildExporterFor..st
+++ b/src/ExercismPharoTooling.package/Exercism.class/class/buildExporterFor..st
@@ -1,0 +1,11 @@
+instance creation
+buildExporterFor: aClass
+	| exporter homeDirectory |
+	homeDirectory := OSEnvironment current getEnv: 'HOME'.
+	
+	exporter := self new.
+	exporter exerciseDirectory: homeDirectory, self exercismDirectory, aClass asString, '/'.
+	exporter ghostDirectory: exporter exerciseDirectory, self ghostDirectory.	
+	exporter exportFile: aClass asString, self fileExtension.
+	exporter exerciseClass: aClass.
+	^ exporter.

--- a/src/ExercismPharoTooling.package/Exercism.class/class/exportClass..st
+++ b/src/ExercismPharoTooling.package/Exercism.class/class/exportClass..st
@@ -1,6 +1,6 @@
 export
 exportClass: aClass
-	"Export aClass into a .st file in the users HOME/exercism/pharo directory."
+	"Export aClass into a .st file in the users HOME/exercism/pharo/<exercise-name>/ directory."
 	| exporter |
-	exporter := self new.
-	exporter exportClass: aClass.
+	exporter := self buildExporterFor: aClass.
+	exporter exportClass.

--- a/src/ExercismPharoTooling.package/Exercism.class/class/ghostDirectory.st
+++ b/src/ExercismPharoTooling.package/Exercism.class/class/ghostDirectory.st
@@ -1,0 +1,4 @@
+constants
+ghostDirectory
+	"This directory is to contain hidden machine readable files that should not be edited or read by humans."
+	^ '.ghost/'.

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/exerciseClass..st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/exerciseClass..st
@@ -1,0 +1,3 @@
+accessing
+exerciseClass: aClass 
+	exerciseClass := aClass.

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/exerciseClass.st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/exerciseClass.st
@@ -1,0 +1,3 @@
+accessing
+exerciseClass
+	^ exerciseClass

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/exerciseDirectory..st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/exerciseDirectory..st
@@ -1,0 +1,3 @@
+accessing
+exerciseDirectory: aPath
+	exerciseDirectory := aPath.

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/exerciseDirectory.st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/exerciseDirectory.st
@@ -1,0 +1,3 @@
+accessing
+exerciseDirectory
+	^ exerciseDirectory

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/exportClass..st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/exportClass..st
@@ -1,9 +1,0 @@
-export
-exportClass: aClass
-	"Export aClass as a .st file to the users Exercism directory."
-	| exportFile exportStream |
-	exportFile := aClass asString, self class fileExtension.
-	exportStream := FileStream newFileNamed: homeDirectory, exercismDirectory, exportFile.
-	
-	aClass fileOutOn: exportStream.
-	

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/exportClass.st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/exportClass.st
@@ -1,0 +1,10 @@
+export
+exportClass
+	"Export exportFile as a .st file to the users Exercism exercise directory as a human readable file and as a machine readable file."
+
+	| exportGhostPath exportGhostStream |
+	exportGhostPath := ghostDirectory, exportFile.
+	exportGhostStream := StandardFileStream newFileNamed: exportGhostPath.
+
+	exerciseClass fileOutOn: exportGhostStream.
+	self fileOutHumanReadableFileFrom: exportGhostPath.

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/exportFile..st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/exportFile..st
@@ -1,0 +1,3 @@
+accessing
+exportFile: aString
+	exportFile := aString.

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/exportFile.st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/exportFile.st
@@ -1,0 +1,3 @@
+accessing
+exportFile
+	^ exportFile

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/fileOutHumanReadableFileFrom..st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/fileOutHumanReadableFileFrom..st
@@ -1,0 +1,10 @@
+export
+fileOutHumanReadableFileFrom: aFile
+	"Write a file without machine readable metadata or artifacts."
+	
+	| chunks humanReadableFile fileStream |
+	chunks := CodeImporter chunksFromFileNamed: aFile.
+	humanReadableFile := exerciseDirectory, exportFile.
+	fileStream := StandardFileStream newFileNamed: humanReadableFile.
+	chunks do: [ :chunk | fileStream  nextPutAll: chunk contents; cr; cr. ].
+	fileStream flush.

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/ghostDirectory..st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/ghostDirectory..st
@@ -1,0 +1,4 @@
+accessing
+ghostDirectory: aPath
+	ghostDirectory := aPath.
+	

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/ghostDirectory.st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/ghostDirectory.st
@@ -1,0 +1,3 @@
+accessing
+ghostDirectory
+	^ ghostDirectory

--- a/src/ExercismPharoTooling.package/Exercism.class/instance/initialize.st
+++ b/src/ExercismPharoTooling.package/Exercism.class/instance/initialize.st
@@ -1,4 +1,3 @@
 initialization
 initialize
 	homeDirectory := OSEnvironment current getEnv: 'HOME'.
-	exercismDirectory := self class exercismDirectory.

--- a/src/ExercismPharoTooling.package/Exercism.class/properties.json
+++ b/src/ExercismPharoTooling.package/Exercism.class/properties.json
@@ -1,13 +1,15 @@
 {
-	"commentStamp" : "SamuelWilson 6/21/2018 19:57",
+	"commentStamp" : "SamuelWilson 6/28/2018 20:12",
 	"super" : "Object",
 	"category" : "ExercismPharoTooling",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"homeDirectory",
-		"exercismDirectory"
+		"exerciseDirectory",
+		"exportFile",
+		"ghostDirectory",
+		"exerciseClass"
 	],
 	"name" : "Exercism",
 	"type" : "normal"

--- a/src/ExercismPharoTooling.package/ExercismTest.class/README.md
+++ b/src/ExercismPharoTooling.package/ExercismTest.class/README.md
@@ -1,0 +1,2 @@
+# Exercism Pharo Tooling Test Suite
+I am the test suite for the Exercism Pharo Tooling.

--- a/src/ExercismPharoTooling.package/ExercismTest.class/instance/setUp.st
+++ b/src/ExercismPharoTooling.package/ExercismTest.class/instance/setUp.st
@@ -1,0 +1,19 @@
+running
+setUp
+	| exerciseDirectory exercismDirectory ghostDirectory fileName fileExtension homeDirectory | 
+	sampleClass := Exercism.
+	homeDirectory := OSEnvironment current getEnv: 'HOME'.
+	exercismDirectory := homeDirectory, Exercism exercismDirectory.
+	exerciseDirectory := exercismDirectory, sampleClass asString, '/'.
+	ghostDirectory := Exercism ghostDirectory.
+	fileName := sampleClass asString.
+	fileExtension := Exercism fileExtension.
+	
+	exporter := Exercism new.
+	exporter exerciseDirectory: exercismDirectory, sampleClass asString, '/'.
+	exporter ghostDirectory: exerciseDirectory, ghostDirectory.
+	exporter exportFile: fileName, fileExtension.
+	exporter exerciseClass: sampleClass.
+
+	
+	

--- a/src/ExercismPharoTooling.package/ExercismTest.class/instance/testBuildExporterFor.st
+++ b/src/ExercismPharoTooling.package/ExercismTest.class/instance/testBuildExporterFor.st
@@ -1,0 +1,13 @@
+tests
+testBuildExporterFor
+	| actual expected |
+	expected := exporter.
+	
+	actual := Exercism buildExporterFor: sampleClass.
+	
+	self assert: actual exerciseDirectory equals: expected exerciseDirectory.
+	self assert: actual ghostDirectory equals: expected ghostDirectory.
+	self assert: actual exportFile equals: expected exportFile.
+	self assert: actual exerciseClass equals: expected exerciseClass. 
+	
+	

--- a/src/ExercismPharoTooling.package/ExercismTest.class/properties.json
+++ b/src/ExercismPharoTooling.package/ExercismTest.class/properties.json
@@ -1,0 +1,16 @@
+{
+	"commentStamp" : "SamuelWilson 6/23/2018 17:09",
+	"super" : "TestCase",
+	"category" : "ExercismPharoTooling-Test",
+	"classinstvars" : [
+		"sampleClass"
+	],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"exporter",
+		"sampleClass"
+	],
+	"name" : "ExercismTest",
+	"type" : "normal"
+}

--- a/src/ExercismPharoTooling.package/monticello.meta/categories.st
+++ b/src/ExercismPharoTooling.package/monticello.meta/categories.st
@@ -1,1 +1,2 @@
 SystemOrganization addCategory: #ExercismPharoTooling!
+SystemOrganization addCategory: 'ExercismPharoTooling-Test'!


### PR DESCRIPTION
This change allows for the export of a exercise to one text file in the
standard machine readable 'chunk' format, and another file with
machine artifacts and metadata removed to aid human readability.